### PR TITLE
Provide Geo Queries Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -750,10 +750,16 @@ curl -X GET \
 
 This example shows the latest four sampled `luminosity` values of lamps that
 are within a 5 km radius from `52°33'16.9"N 13°23'55.0"E` (Bornholmer Straße
-65, Berlin, Germany). If you have turned on all your lamps, you should see
-data for `Lamp:001` and `Lamp:004`.
+65, Berlin, Germany). If you have turned on all the lamps available on the
+device monitor page, you should be able to see data for `Lamp:001` and
+`Lamp:004`.
 
-#### :ten: Request:
+> :information_source: **Note:** Geographical queries are only available
+> starting from version `0.5` of QuantumLeap which implements the full
+> set of queries detailed in the Geographical Queries section of the
+> [NGSI v2 specification](http://fiware.github.io/specifications/ngsiv2/stable/).
+
+#### :one::zero: Request:
 
 ```console
 curl -X GET \
@@ -802,10 +808,16 @@ curl -X GET \
 
 This example shows the latest four sampled `luminosity` values of lamps that
 are inside a square of side 200 m centred at `52°33'16.9"N 13°23'55.0"E`
-(Bornholmer Straße 65, Berlin, Germany). Even if you have turned on all your
-lamps, you should only see data for `Lamp:001`.
+(Bornholmer Straße 65, Berlin, Germany). Even if you have turned on all the
+lamps available on the device monitor page, you should only see data for
+`Lamp:001`.
 
-#### :eleven: Request:
+> :information_source: **Note:** Geographical queries are only available
+> starting from version `0.5` of QuantumLeap which implements the full
+> set of queries detailed in the Geographical Queries section of the
+> [NGSI v2 specification](http://fiware.github.io/specifications/ngsiv2/stable/).
+
+#### :one::one: Request:
 
 ```console
 curl -X GET \
@@ -875,7 +887,7 @@ Another way to see if data are being persisted is to check if a `table_schema`
 has been created. This can be done by making a request to the **CrateDB** HTTP
 endpoint as shown:
 
-#### :one::zero: Request:
+#### :one::two: Request:
 
 ```console
 curl -iX POST \
@@ -914,7 +926,7 @@ configured to send data to the correct location.
 database based on the entity type. Table names are formed with the `et` prefix
 and the entity type name in lowercase.
 
-#### :one::one: Request:
+#### :one::three: Request:
 
 ```console
 curl -X POST \
@@ -943,7 +955,7 @@ The SQL statement uses `ORDER BY` and `LIMIT` clauses to sort the data. More
 details can be found under within the **CrateDB**
 [documentation](https://crate.io/docs/crate/reference/en/latest/sql/statements/select.html)
 
-#### :one::two: Request:
+#### :one::four: Request:
 
 ```console
 curl -iX POST \
@@ -979,7 +991,7 @@ The SQL statement uses an `OFFSET` clause to retrieve the required rows. More
 details can be found under within the **CrateDB**
 [documentation](https://crate.io/docs/crate/reference/en/latest/sql/statements/select.html).
 
-#### :one::three: Request:
+#### :one::five: Request:
 
 ```console
 curl -iX POST \
@@ -1016,7 +1028,7 @@ clause to retrieve the last N rows. More details can be found under within the
 **CrateDB**
 [documentation](https://crate.io/docs/crate/reference/en/latest/sql/statements/select.html).
 
-#### :one::four: Request:
+#### :one::six: Request:
 
 ```console
 curl -iX POST \
@@ -1053,7 +1065,7 @@ relevant data. **CrateDB** offers a range of
 [Date-Time Functions](https://crate.io/docs/crate/reference/en/latest/general/builtins/scalar.html#date-and-time-functions)
 to truncate and convert the timestamps into data which can be grouped.
 
-#### :one::five: Request:
+#### :one::seven: Request:
 
 ```console
 curl -iX POST \
@@ -1086,7 +1098,7 @@ relevant data. **CrateDB** offers a range of
 [Date-Time Functions](https://crate.io/docs/crate/reference/en/latest/general/builtins/scalar.html#date-and-time-functions)
 to truncate and convert the timestamps into data which can be grouped.
 
-#### :one::six: Request:
+#### :one::eight: Request:
 
 ```console
 curl -iX POST \
@@ -1119,7 +1131,7 @@ relevant data. **CrateDB** offers a range of
 [Aggregate Functions](https://crate.io/docs/crate/reference/en/latest/general/dql/selects.html#data-aggregation)
 to aggregate data in different ways.
 
-#### :one::seven: Request:
+#### :one::nine: Request:
 
 ```console
 curl -iX POST \

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ curl -iX POST \
       "url": "http://quantumleap:8668/v2/notify"
     },
     "attrs": [
-      "luminosity"
+      "luminosity", "location"
     ],
     "metadata": ["dateCreated", "dateModified"]
   },
@@ -743,6 +743,103 @@ curl -X GET \
         "index": [],
         "values": [1753]
     }
+}
+```
+
+### QuantumLeap API - List the latest N Sampled Values of Devices near a Point
+
+This example shows the latest four sampled `luminosity` values of lamps that
+are within a 5 km radius from `52°33'16.9"N 13°23'55.0"E` (Bornholmer Straße
+65, Berlin, Germany). If you have turned on all your lamps, you should see
+data for `Lamp:001` and `Lamp:004`.
+
+#### :ten: Request:
+
+```console
+curl -X GET \
+  'http://localhost:8668/v2/types/Lamp/attrs/luminosity?lastN=4&georel=near;maxDistance:5000&geometry=point&coords=52.5547,13.3986' \
+  -H 'Accept: application/json' \
+  -H 'Fiware-Service: openiot' \
+  -H 'Fiware-ServicePath: /'
+```
+
+#### Response:
+
+```json
+{
+  "data": {
+    "attrName": "luminosity",
+    "entities": [
+      {
+        "entityId": "Lamp:001",
+        "index": [
+          "2018-12-13T16:35:58.284",
+          "2018-12-13T16:36:58.216"
+        ],
+        "values": [
+          999,
+          999
+        ]
+      },
+      {
+        "entityId": "Lamp:004",
+        "index": [
+          "2018-12-13T16:35:04.351",
+          "2018-12-13T16:36:04.282"
+        ],
+        "values": [
+          948,
+          948
+        ]
+      }
+    ],
+    "entityType": "Lamp"
+  }
+}
+```
+
+### QuantumLeap API - List the latest N Sampled Values of Devices in an Area
+
+This example shows the latest four sampled `luminosity` values of lamps that
+are inside a square of side 200 m centred at `52°33'16.9"N 13°23'55.0"E`
+(Bornholmer Straße 65, Berlin, Germany). Even if you have turned on all your
+lamps, you should only see data for `Lamp:001`.
+
+#### :eleven: Request:
+
+```console
+curl -X GET \
+  'http://localhost:8668/v2/types/Lamp/attrs/luminosity?lastN=4&georel=coveredBy&geometry=polygon&coords=52.5537,13.3996;52.5557,13.3996;52.5557,13.3976;52.5537,13.3976;52.5537,13.3996' \
+  -H 'Accept: application/json' \
+  -H 'Fiware-Service: openiot' \
+  -H 'Fiware-ServicePath: /'
+```
+
+#### Response:
+
+```json
+{
+  "data": {
+    "attrName": "luminosity",
+    "entities": [
+      {
+        "entityId": "Lamp:001",
+        "index": [
+          "2018-12-13T17:08:56.041",
+          "2018-12-13T17:09:55.976",
+          "2018-12-13T17:10:55.907",
+          "2018-12-13T17:11:55.833"
+        ],
+        "values": [
+          999,
+          999,
+          999,
+          999
+        ]
+      }
+    ],
+    "entityType": "Lamp"
+  }
 }
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
 
 
   quantumleap:
-    image: smartsdk/quantumleap:0.4.1
+    image: smartsdk/quantumleap:0.5
     hostname: quantumleap
     container_name: fiware-quantumleap
     ports:

--- a/provision-devices
+++ b/provision-devices
@@ -112,7 +112,8 @@ curl -X POST \
         {"object_id": "l", "name": "luminosity", "type":"Integer"}
        ],
        "static_attributes": [
-         {"name":"refStore", "type": "Relationship","value": "Store:001"}
+         {"name":"refStore", "type": "Relationship","value": "Store:001"},
+         {"name":"location", "type":"geo:point", "value":"52.5547,13.3986"}
     	]
     }
   ]
@@ -281,7 +282,8 @@ curl -X POST \
         {"object_id": "l", "name": "luminosity", "type":"Integer"}
        ],
        "static_attributes": [
-         {"name":"refStore", "type": "Relationship","value": "Store:002"}
+         {"name":"refStore", "type": "Relationship","value": "Store:002"},
+         {"name":"location", "type":"geo:point", "value":"52.5075,13.3903"}
     	]
     }
   ]
@@ -450,7 +452,8 @@ curl -X POST \
         {"object_id": "l", "name": "luminosity", "type":"Integer"}
        ],
        "static_attributes": [
-         {"name":"refStore", "type": "Relationship","value": "Store:003"}
+         {"name":"refStore", "type": "Relationship","value": "Store:003"},
+         {"name":"location", "type":"geo:point", "value":"52.5031,13.4447"}
     	]
     }
   ]
@@ -619,7 +622,8 @@ curl -X POST \
         {"object_id": "l", "name": "luminosity", "type":"Integer"}
        ],
        "static_attributes": [
-         {"name":"refStore", "type": "Relationship","value": "Store:004"}
+         {"name":"refStore", "type": "Relationship","value": "Store:004"},
+         {"name":"location", "type":"geo:point", "value":"52.5208,13.4094"}
     	]
     }
   ]


### PR DESCRIPTION
This PR updates the QuantumLeap tutorial to provide examples of geographical queries which will be available starting from version `0.5` of QuantumLeap---soon to be released.

Points to note.

1. **QuantumLeap docker image**. Changed from `0.4.1` to `0.5` in `docker-compose.yml` but QuantumLeap `v0.5` hasn't been released yet so this PR should only be merged into master after the `0.5` image gets published to docker hub.
2. **Postman**. Request 10 and 11 need to be included in the Postman collection.
3. **Japanese Translation**. Still to do.
4. **Geo data**. Added location to each lamp device in order to be able to use it in geo query examples. For each lamp, the location is the same as that of shop the lamp is in---`Lamp:001` location = `Shop:001` location, etc.
