### PR TITLE
Remove unnecessary code

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,7 +441,6 @@ curl -X GET \
   'http://localhost:1026/v2/subscriptions/' \
   -H 'fiware-service: openiot' \
   -H 'fiware-servicepath: /'
-}'
 ```
 
 #### Response:


### PR DESCRIPTION
The curl command doesn't work properly because of including unnecessary code.