### PR TITLE
Modify resource limits and reservations in common.yml

### DIFF
--- a/docker-compose/common.yml
+++ b/docker-compose/common.yml
@@ -88,11 +88,11 @@ services:
     deploy:
       resources:
         limits:
+          memory: 1024M
+          cpus: '2.0'
+        reservations:
           memory: 512M
           cpus: '1.0'
-        reservations:
-          memory: 256M
-          cpus: '0.5'
     environment:
       - IOTA_NORTH_PORT=${IOTA_NORTH_PORT}
       - IOTA_REGISTRY_TYPE=mongodb #Whether to hold IoT device info in memory or in a database


### PR DESCRIPTION
Updated resource limits and reservations for memory and CPUs. Previous values made the IoT Agent to hang with 99% CPU consumption.